### PR TITLE
 cli: debugzip sensitive fields redaction guarded through cluster settings

### DIFF
--- a/pkg/cli/settings.go
+++ b/pkg/cli/settings.go
@@ -1,0 +1,19 @@
+package cli
+
+import "github.com/cockroachdb/cockroach/pkg/settings"
+
+const (
+	baseDebugZipSettingName                            = "debug.zip"
+	DebugZipSensitiveFieldsRedactionEnabledSettingName = baseDebugZipSettingName + "redact_sensitive.enabled"
+)
+
+// DebugZipSensitiveFieldsRedactionEnabled guards whether hostname / ip address and other sensitive fields
+// should be redacted in the debug zip
+var DebugZipSensitiveFieldsRedactionEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	DebugZipSensitiveFieldsRedactionEnabledSettingName,
+	"enables or disabled hostname / ip address redaction in debug zip",
+	false,
+	settings.WithPublic,
+	settings.WithReportable(true),
+)

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -122,11 +122,11 @@ func (zc *debugZipContext) collectClusterData(
 			if err != nil {
 				return err
 			}
-			nodesStatus, err = zc.status.Nodes(ctx, &serverpb.NodesRequest{Redact: zipCtx.redact})
+			nodesStatus, err = zc.status.Nodes(ctx, &serverpb.NodesRequest{Redact: shouldRedact()})
 			if err != nil {
 				return err
 			}
-			nodesListRedacted, err = zc.status.NodesList(ctx, &serverpb.NodesListRequest{Redact: zipCtx.redact})
+			nodesListRedacted, err = zc.status.NodesList(ctx, &serverpb.NodesListRequest{Redact: shouldRedact()})
 			return err
 		})
 
@@ -145,7 +145,7 @@ func (zc *debugZipContext) collectClusterData(
 			// In case the NodesList() RPC failed), we still want to inspect the
 			// per-node endpoints on the head node.
 			s = zc.clusterPrinter.start("retrieving the node status")
-			firstNodeDetails, err := zc.status.Details(ctx, &serverpb.DetailsRequest{NodeId: "local", Redact: zipCtx.redact})
+			firstNodeDetails, err := zc.status.Details(ctx, &serverpb.DetailsRequest{NodeId: "local", Redact: shouldRedact()})
 			if err != nil {
 				return &serverpb.NodesListResponse{}, &serverpb.NodesListResponse{}, nil, err
 			}
@@ -220,4 +220,8 @@ func (zc *debugZipContext) collectClusterData(
 	}
 
 	return nodesList, nodesListRedacted, livenessByNodeID, nil
+}
+
+func shouldRedact() bool {
+	return zipCtx.redact && DebugZipSensitiveFieldsRedactionEnabled.Get(&serverCfg.Settings.SV)
 }

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -37,13 +37,13 @@ func makePerNodeZipRequests(prefix, id string, status serverpb.StatusClient) []z
 	return []zipRequest{
 		{
 			fn: func(ctx context.Context) (interface{}, error) {
-				return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Redact: zipCtx.redact})
+				return status.Details(ctx, &serverpb.DetailsRequest{NodeId: id, Redact: shouldRedact()})
 			},
 			pathName: prefix + "/details",
 		},
 		{
 			fn: func(ctx context.Context) (interface{}, error) {
-				return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id, Redact: zipCtx.redact})
+				return status.Gossip(ctx, &serverpb.GossipRequest{NodeId: id, Redact: shouldRedact()})
 			},
 			pathName: prefix + "/gossip",
 		},
@@ -538,7 +538,7 @@ func (zc *debugZipContext) collectPerNodeData(
 		s = nodePrinter.start("requesting ranges")
 		if requestErr := zc.runZipFn(ctx, s, func(ctx context.Context) error {
 			var err error
-			ranges, err = zc.status.Ranges(ctx, &serverpb.RangesRequest{NodeId: id, Redact: zipCtx.redact})
+			ranges, err = zc.status.Ranges(ctx, &serverpb.RangesRequest{NodeId: id, Redact: shouldRedact()})
 			return err
 		}); requestErr != nil {
 			if err := zc.z.createError(s, prefix+"/ranges", requestErr); err != nil {


### PR DESCRIPTION
Even though redaction is enabled while taking debug zip, some customers would be fine sharing sensitive information like host name, ip addresses. This PR introduces a cluster setting which can be switched on or off to control whether such sensitive fields should be redacted. If off, sensitive fields won't get redacted. If on, those fields will get redacted.